### PR TITLE
Fix calculate swap

### DIFF
--- a/src/contracts/errors.rs
+++ b/src/contracts/errors.rs
@@ -28,6 +28,7 @@ pub enum InvariantError {
     NotEmptyTickDeinitialization,
     InvalidInitTick,
     InvalidInitSqrtPrice,
+    InvalidTickIndex,
 }
 
 execution_error! {
@@ -58,6 +59,7 @@ execution_error! {
         NotEmptyTickDeinitialization => 23,
         InvalidInitTick => 24,
         InvalidInitSqrtPrice => 25,
+        InvalidTickIndex => 26,
     }
 }
 
@@ -134,6 +136,9 @@ pub fn unwrap_invariant_result<T>(invariant_error: Result<T, InvariantError>) ->
             }
             InvariantError::InvalidInitSqrtPrice => {
                 contract_env::revert(InvariantErrorReturn::InvalidInitSqrtPrice)
+            }
+            InvariantError::InvalidTickIndex => {
+                contract_env::revert(InvariantErrorReturn::InvalidTickIndex)
             }
         },
     }

--- a/src/contracts/errors.rs
+++ b/src/contracts/errors.rs
@@ -29,6 +29,7 @@ pub enum InvariantError {
     InvalidInitTick,
     InvalidInitSqrtPrice,
     InvalidTickIndex,
+    TickLimitReached,
 }
 
 execution_error! {
@@ -60,6 +61,7 @@ execution_error! {
         InvalidInitTick => 24,
         InvalidInitSqrtPrice => 25,
         InvalidTickIndex => 26,
+        TickLimitReached => 27,
     }
 }
 
@@ -139,6 +141,9 @@ pub fn unwrap_invariant_result<T>(invariant_error: Result<T, InvariantError>) ->
             }
             InvariantError::InvalidTickIndex => {
                 contract_env::revert(InvariantErrorReturn::InvalidTickIndex)
+            }
+            InvariantError::TickLimitReached => {
+                contract_env::revert(InvariantErrorReturn::TickLimitReached)
             }
         },
     }

--- a/src/contracts/storage/pool.rs
+++ b/src/contracts/storage/pool.rs
@@ -29,6 +29,13 @@ pub struct Pool {
     pub fee_receiver: Address,
 }
 
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum UpdatePoolTick {
+    NoTick,
+    TickInitialized(Tick),
+    TickUninitialized(i32),
+}
+
 impl Default for Pool {
     fn default() -> Self {
         Self {
@@ -155,7 +162,7 @@ impl Pool {
         &mut self,
         result: SwapResult,
         swap_limit: SqrtPrice,
-        tick: Option<&mut Tick>,
+        tick: &mut UpdatePoolTick,
         mut remaining_amount: TokenAmount,
         by_amount_in: bool,
         x_to_y: bool,
@@ -165,17 +172,27 @@ impl Pool {
     ) -> (TokenAmount, TokenAmount, bool) {
         let mut has_crossed = false;
         let mut total_amount = TokenAmount::new(U256::from(0));
-        match tick {
-            Some(tick) if result.next_sqrt_price == swap_limit => {
-                let is_enough_amount_to_cross = unwrap!(is_enough_amount_to_change_price(
-                    remaining_amount,
-                    result.next_sqrt_price,
-                    self.liquidity,
-                    fee_tier.fee,
-                    by_amount_in,
-                    x_to_y,
-                ));
 
+        if UpdatePoolTick::NoTick == *tick || swap_limit != result.next_sqrt_price {
+            self.current_tick_index = unwrap!(get_tick_at_sqrt_price(
+                result.next_sqrt_price,
+                fee_tier.tick_spacing
+            ));
+
+            return (total_amount, remaining_amount, has_crossed);
+        };
+
+        let is_enough_amount_to_cross = unwrap!(is_enough_amount_to_change_price(
+            remaining_amount,
+            result.next_sqrt_price,
+            self.liquidity,
+            fee_tier.fee,
+            by_amount_in,
+            x_to_y,
+        ));
+
+        let tick_index = match tick {
+            UpdatePoolTick::TickInitialized(tick) => {
                 if !x_to_y || is_enough_amount_to_cross {
                     let _ = tick.cross(self, current_timestamp);
                     has_crossed = true;
@@ -187,20 +204,17 @@ impl Pool {
                     remaining_amount = TokenAmount::new(U256::from(0));
                 }
 
-                // set tick to limit (below if price is going down, because current tick should always be below price)
-                self.current_tick_index = if x_to_y && is_enough_amount_to_cross {
-                    tick.index - fee_tier.tick_spacing as i32
-                } else {
-                    tick.index
-                };
+                tick.index
             }
-            _ => {
-                self.current_tick_index = unwrap!(get_tick_at_sqrt_price(
-                    result.next_sqrt_price,
-                    fee_tier.tick_spacing
-                ));
-            }
-        }
+            UpdatePoolTick::TickUninitialized(index) => *index,
+            _ => panic!("Horrible things happened"),
+        };
+
+        self.current_tick_index = if x_to_y && is_enough_amount_to_cross {
+            tick_index - fee_tier.tick_spacing as i32
+        } else {
+            tick_index
+        };
 
         (total_amount, remaining_amount, has_crossed)
     }

--- a/src/contracts/storage/tick.rs
+++ b/src/contracts/storage/tick.rs
@@ -7,7 +7,7 @@ use odra::types::{U128, U256};
 use odra::OdraType;
 use traceable_result::*;
 
-#[derive(OdraType, PartialEq, Debug, Copy)]
+#[derive(OdraType, PartialEq, Debug, Copy, Eq)]
 pub struct Tick {
     pub index: i32,
     pub sign: bool,

--- a/src/contracts/storage/tickmap.rs
+++ b/src/contracts/storage/tickmap.rs
@@ -1,4 +1,5 @@
 use super::PoolKey;
+use crate::contracts::InvariantError;
 use crate::math::sqrt_price::calculate_sqrt_price;
 use crate::math::sqrt_price::SqrtPrice;
 use crate::math::{CHUNK_SIZE, MAX_TICK, TICK_SEARCH_RANGE};
@@ -170,7 +171,7 @@ impl Tickmap {
         current_tick: i32,
         tick_spacing: u32,
         pool_key: PoolKey,
-    ) -> (SqrtPrice, Option<(i32, bool)>) {
+    ) -> Result<(SqrtPrice, Option<(i32, bool)>), InvariantError> {
         let closes_tick_index = if x_to_y {
             self.prev_initialized(current_tick, tick_spacing, pool_key)
         } else {
@@ -184,23 +185,25 @@ impl Tickmap {
                 if (x_to_y && sqrt_price > sqrt_price_limit)
                     || (!x_to_y && sqrt_price < sqrt_price_limit)
                 {
-                    (sqrt_price, Some((index, true)))
+                    Ok((sqrt_price, Some((index, true))))
                 } else {
-                    (sqrt_price_limit, None)
+                    Ok((sqrt_price_limit, None))
                 }
             }
             None => {
                 let index = get_search_limit(current_tick, tick_spacing, !x_to_y);
                 let sqrt_price = calculate_sqrt_price(index).unwrap();
 
-                assert!(current_tick != index, "LimitReached");
+                if current_tick == index {
+                    return Err(InvariantError::TickLimitReached);
+                }
 
                 if (x_to_y && sqrt_price > sqrt_price_limit)
                     || (!x_to_y && sqrt_price < sqrt_price_limit)
                 {
-                    (sqrt_price, Some((index, false)))
+                    Ok((sqrt_price, Some((index, false))))
                 } else {
-                    (sqrt_price_limit, None)
+                    Ok((sqrt_price_limit, None))
                 }
             }
         }
@@ -250,37 +253,37 @@ mod tests {
         tickmap.flip(true, 0, 1, pool_key);
         // tick limit closer
         {
-            // let (result, from_tick) =
-            // let result = tickmap::Tickmap::get_closer_limit(
-            let _result =
-                tickmap.get_closer_limit(SqrtPrice::from_integer(5), true, 100, 1, pool_key);
-            // println!("Result: {:?}", result);
+            let (result, from_tick) = tickmap
+                .get_closer_limit(SqrtPrice::from_integer(5), true, 100, 1, pool_key)
+                .unwrap();
 
-            // let expected = Price::from_integer(5);
-            let _expected = SqrtPrice::from_integer(5);
-            // assert_eq!(result, expected);
-            // assert_eq!(from_tick, None);
+            let expected = SqrtPrice::from_integer(5);
+            assert_eq!(result, expected);
+            assert_eq!(from_tick, None);
         }
         // trade limit closer
         {
-            let (result, from_tick) =
-                tickmap.get_closer_limit(SqrtPrice::from_scale(1, 1), true, 100, 1, pool_key);
+            let (result, from_tick) = tickmap
+                .get_closer_limit(SqrtPrice::from_scale(1, 1), true, 100, 1, pool_key)
+                .unwrap();
             let expected = SqrtPrice::from_integer(1);
             assert_eq!(result, expected);
             assert_eq!(from_tick, Some((0, true)));
         }
         // other direction
         {
-            let (result, from_tick) =
-                tickmap.get_closer_limit(SqrtPrice::from_integer(2), false, -5, 1, pool_key);
+            let (result, from_tick) = tickmap
+                .get_closer_limit(SqrtPrice::from_integer(2), false, -5, 1, pool_key)
+                .unwrap();
             let expected = SqrtPrice::from_integer(1);
             assert_eq!(result, expected);
             assert_eq!(from_tick, Some((0, true)));
         }
         // other direction
         {
-            let (result, from_tick) =
-                tickmap.get_closer_limit(SqrtPrice::from_scale(1, 1), false, -100, 10, pool_key);
+            let (result, from_tick) = tickmap
+                .get_closer_limit(SqrtPrice::from_scale(1, 1), false, -100, 10, pool_key)
+                .unwrap();
             let expected = SqrtPrice::from_scale(1, 1);
             assert_eq!(result, expected);
             assert_eq!(from_tick, None);
@@ -697,13 +700,10 @@ mod tests {
         // initalized edges
         {
             for spacing in 1..=10 {
-                //println!("spacing = {}", spacing);
                 let tickmap = &mut TickmapDeployer::default();
 
                 let max_index = MAX_TICK - MAX_TICK % spacing;
                 let min_index = -max_index;
-                //println!("max_index = {}", max_index);
-                //println!("min_index = {}", min_index);
 
                 tickmap.flip(true, max_index, spacing as u32, pool_key);
                 tickmap.flip(true, min_index, spacing as u32, pool_key);
@@ -715,12 +715,7 @@ mod tests {
                 let next =
                     tickmap.next_initialized(max_index - tick_edge_diff, spacing as u32, pool_key);
 
-                if prev.is_some() {
-                    //println!("found prev = {}", prev.unwrap());
-                }
-                if next.is_some() {
-                    //println!("found next = {}", next.unwrap());
-                }
+                assert_eq!((prev.is_some(), next.is_some()), (true, true));
 
                 // cleanup
                 {
@@ -742,12 +737,7 @@ mod tests {
             let next =
                 tickmap.next_initialized(max_index - tick_edge_diff, spacing as u32, pool_key);
 
-            if prev.is_some() {
-                //println!("found prev = {}", prev.unwrap());
-            }
-            if next.is_some() {
-                //println!("found next = {}", next.unwrap());
-            }
+            assert_eq!((prev.is_some(), next.is_some()), (false, false));
         }
     }
 }

--- a/src/e2e/base/position.rs
+++ b/src/e2e/base/position.rs
@@ -82,6 +82,54 @@ fn test_create_position() {
 }
 
 #[test]
+#[should_panic]
+fn test_position_same_upper_and_lower_tick() {
+    let position_owner = test_env::get_account(0);
+    test_env::set_caller(position_owner);
+
+    let mint_amount = U256::from(500);
+    let fee = Percentage::new(U128::from(0));
+    let (mut invariant, mut token_x, mut token_y) = init(fee, mint_amount);
+
+    let fee_tier = FeeTier::new(Percentage::new(U128::from(0)), 1).unwrap();
+    let pool_key = PoolKey::new(*token_x.address(), *token_y.address(), fee_tier).unwrap();
+
+    invariant
+        .add_fee_tier(fee_tier.fee.get(), fee_tier.tick_spacing)
+        .unwrap();
+
+    invariant
+        .create_pool(
+            pool_key.token_x,
+            pool_key.token_y,
+            fee_tier.fee.get(),
+            fee_tier.tick_spacing,
+            calculate_sqrt_price(10).unwrap().get(),
+            10,
+        )
+        .unwrap();
+
+    token_x.approve(invariant.address(), &U256::from(500));
+    token_y.approve(invariant.address(), &U256::from(500));
+
+    let lower_tick = 10;
+    let upper_tick = lower_tick;
+    let liquidity_delta = Liquidity::new(U256::from(10));
+
+    invariant.create_position(
+        pool_key.token_x,
+        pool_key.token_y,
+        fee_tier.fee.get(),
+        fee_tier.tick_spacing,
+        lower_tick,
+        upper_tick,
+        liquidity_delta.get(),
+        SqrtPrice::new(U128::from(0)).get(),
+        SqrtPrice::max_instance().get(),
+    ).unwrap();
+}
+
+#[test]
 fn test_remove_position() {
     let position_owner = test_env::get_account(0);
     test_env::set_caller(position_owner);

--- a/src/e2e/base/position.rs
+++ b/src/e2e/base/position.rs
@@ -116,17 +116,19 @@ fn test_position_same_upper_and_lower_tick() {
     let upper_tick = lower_tick;
     let liquidity_delta = Liquidity::new(U256::from(10));
 
-    invariant.create_position(
-        pool_key.token_x,
-        pool_key.token_y,
-        fee_tier.fee.get(),
-        fee_tier.tick_spacing,
-        lower_tick,
-        upper_tick,
-        liquidity_delta.get(),
-        SqrtPrice::new(U128::from(0)).get(),
-        SqrtPrice::max_instance().get(),
-    ).unwrap();
+    invariant
+        .create_position(
+            pool_key.token_x,
+            pool_key.token_y,
+            fee_tier.fee.get(),
+            fee_tier.tick_spacing,
+            lower_tick,
+            upper_tick,
+            liquidity_delta.get(),
+            SqrtPrice::new(U128::from(0)).get(),
+            SqrtPrice::max_instance().get(),
+        )
+        .unwrap();
 }
 
 #[test]

--- a/src/e2e/base/swap.rs
+++ b/src/e2e/base/swap.rs
@@ -250,8 +250,8 @@ fn test_swap_x_to_y() {
                 pool_key.token_y,
                 fee_tier.fee.get(),
                 fee_tier.tick_spacing,
+                lower_tick - 20,
                 middle_tick,
-                upper_tick - 20,
                 liquidity.get(),
                 slippage_limit_lower.get(),
                 slippage_limit_upper.get(),
@@ -281,7 +281,7 @@ fn test_swap_x_to_y() {
         let amount_x = token_x.balance_of(invariant.address());
         let amount_y = token_y.balance_of(invariant.address());
         assert_eq!(amount_x, U256::from(500));
-        assert_eq!(amount_y, U256::from(1000));
+        assert_eq!(amount_y, U256::from(2499));
 
         let dex_x_before = token_x.balance_of(invariant.address());
         let dex_y_before = token_y.balance_of(invariant.address());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ use crate::math::{check_tick, percentage::Percentage, sqrt_price::SqrtPrice};
 use contracts::{events::*, unwrap_invariant_result, InvariantConfig, InvariantErrorReturn};
 use contracts::{
     FeeTier, FeeTiers, Pool, PoolKey, PoolKeys, Pools, Position, Positions, Tick, Tickmap, Ticks,
+    UpdatePoolTick,
 };
 use decimal::*;
 use math::clamm::{calculate_min_amount_out, compute_swap_step, SwapResult};
@@ -172,18 +173,23 @@ impl Invariant {
                 contract_env::revert(InvariantErrorReturn::PriceLimitReached);
             }
 
-            let mut tick = None;
-
-            if let Some((tick_index, is_initialized)) = limiting_tick {
-                if is_initialized {
-                    tick = self.ticks.get(pool_key, tick_index)?.into()
+            let mut tick_update = {
+                if let Some((tick_index, is_initialized)) = limiting_tick {
+                    if is_initialized {
+                        let tick = self.ticks.get(pool_key, tick_index)?;
+                        UpdatePoolTick::TickInitialized(tick)
+                    } else {
+                        UpdatePoolTick::TickUninitialized(tick_index)
+                    }
+                } else {
+                    UpdatePoolTick::NoTick
                 }
             };
 
             let (amount_to_add, amount_after_tick_update, has_crossed) = pool.update_tick(
                 result,
                 swap_limit,
-                tick.as_mut(),
+                &mut tick_update,
                 remaining_amount,
                 by_amount_in,
                 x_to_y,
@@ -195,7 +201,7 @@ impl Invariant {
             remaining_amount = amount_after_tick_update;
             total_amount_in += amount_to_add;
 
-            if let Some(tick) = tick {
+            if let UpdatePoolTick::TickInitialized(tick) = tick_update {
                 if has_crossed {
                     ticks.push(tick)
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -658,6 +658,10 @@ impl Entrypoints for Invariant {
             contract_env::revert(InvariantErrorReturn::ZeroLiquidity);
         }
 
+        if lower_tick == upper_tick {
+            contract_env::revert(InvariantErrorReturn::InvalidTickIndex);
+        }
+
         let mut pool = unwrap_invariant_result(self.pools.get(pool_key));
 
         let mut lower_tick = self.ticks.get(pool_key, lower_tick).unwrap_or_else(|_| {


### PR DESCRIPTION
# Merge after
- #119
# Changes
- refactored calculate_swap logic
- changed get_closer_limit to return an error instead of asserting
- added tests for insufficient liquidity
- fixed tests for tickmap